### PR TITLE
fix typo in path

### DIFF
--- a/Python_Notebooks/Chapter_7.ipynb
+++ b/Python_Notebooks/Chapter_7.ipynb
@@ -374,7 +374,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(datadir+\"Got/GoT.pkl\",\"rb\") as f:\n",
+    "with open(datadir+\"GoT/GoT.pkl\",\"rb\") as f:\n",
     "    Edges, Names, Weights = pickle.load(f)\n"
    ]
   },


### PR DESCRIPTION
@ftheberge - at least on my machine and on GitHub the capitalization in the path is as I propose